### PR TITLE
Remove AssemblyLoadContext from INetStandard15

### DIFF
--- a/platforms.cs
+++ b/platforms.cs
@@ -50,7 +50,6 @@ namespace Analogy
 
     interface INetStandard15 : INetStandard14
     {
-        void AssemblyLoadContext();
     }
 
     // .NET Framework 


### PR DESCRIPTION
`AssemblyLoadContext` is not part of .NET Standard, it's a .NET Core specific API.